### PR TITLE
Apply policy for TypeScript version

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
-  "name": "@ipcrm/sdm-pack-event-relay",
-  "version": "0.1.0",
+  "name": "@atomist/sdm-pack-event-relay",
+  "version": "0.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -3,9 +3,9 @@
   "version": "0.0.1",
   "description": "Atomist SDM Pack Event Relay",
   "author": {
-      "name": "Atomist",
-          "email": "support@atomist.com",
-          "url": "https://atomist.com/"
+    "name": "Atomist",
+    "email": "support@atomist.com",
+    "url": "https://atomist.com/"
   },
   "license": "Apache-2.0",
   "homepage": "https://github.com/atomist/sdm-pack-event-relay#readme",
@@ -49,7 +49,7 @@
     "ts-node": "^8.2.0",
     "tslint": "^5.17.0",
     "typedoc": "^0.14.2",
-    "typescript": "^3.5.1"
+    "typescript": "^3.5.3"
   },
   "directories": {
     "test": "test"


### PR DESCRIPTION
Apply policy `typescript-version::typescript-version`:

_TypeScript Version_
```TypeScript version (^3.5.3)```

---
<details>
<summary>Commands</summary>
<br/>

You can trigger Atomist commands by commenting on this PR:
- `@atomist opt out` will stop raising automatic policy PRs for this repository
- `@atomist help` start your comment with this to ask Atomist for help or provide feedback

[Link this repository to a Slack channel](https://app.atomist.com/workspace/T29E48P34/settings/integrations/slack?repo=atomist%2Fsdm-pack-event-relay) to manage these updates directly from Slack.

</details>

---
<details>
  <summary>Tags</summary>
<br/>
<code>[atomist:generated]</code><br/><code>[auto-branch-delete:on-close]</code><br/><code>[auto-merge-method:squash]</code><br/><code>[auto-merge:on-approve]</code><br/><code>[fingerprint:typescript-version::typescript-version=65546ea5b01bb62f7b74c5d027cb8128f7cda8d5ae207501c0666411a403612d]</code>
</details>